### PR TITLE
Export `HokuleaService`

### DIFF
--- a/ember/package/src/index.ts
+++ b/ember/package/src/index.ts
@@ -42,3 +42,9 @@ export { default as Popover } from './components/popover.gts';
 
 // behavior
 export { default as popover } from './helpers/popover.ts';
+
+// - internal
+export {
+  /** @internal */
+  default as HokuleaService
+} from './services/-hokulea.ts';


### PR DESCRIPTION
... it was forgotten, but required for a pure vite setup.